### PR TITLE
fix compiler warning

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -632,7 +632,7 @@ int u8_isvalid(const char *str, size_t length)
     const unsigned char *p, *pend = (unsigned char*)str + length;
     unsigned char c;
     int ret = 1; /* ASCII */
-    int ab;
+    size_t ab;
 
     for (p = (unsigned char*)str; p < pend; p++) {
         c = *p;


### PR DESCRIPTION
I get:

```
src/utf8.c:645:20: error: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'int' [-Werror,-Wsign-compare]
        if (length < ab)
            ~~~~~~ ^ ~~
1 error generated.
```

with:

```
cutef8 master $ cc -v
Apple LLVM version 5.1 (clang-503.0.40) (based on LLVM 3.4svn)
Target: x86_64-apple-darwin13.2.0
Thread model: posix
cutef8 master $ 
```
