### PR TITLE
Add missing include for integer types.

### DIFF
--- a/utf8.h
+++ b/utf8.h
@@ -1,6 +1,8 @@
 #ifndef UTF8_H
 #define UTF8_H
 
+#include <stdint.h>
+
 extern int locale_is_utf8;
 
 /* is c the start of a utf8 sequence? */


### PR DESCRIPTION
So that uint32_t etc. is understood and the header is self-sufficient.